### PR TITLE
fix: pin secrets-detection actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/secrets-detection.yml
+++ b/.github/workflows/secrets-detection.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Check for secret scanning alerts
         id: secret-scan
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -74,7 +74,7 @@ jobs:
 
       - name: Comment on PR if secrets found
         if: failure() && steps.secret-scan.outputs.secrets_found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Slack Notification on Secrets Detection
         if: failure() && steps.secret-scan.outputs.secrets_found == 'true'
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
           SLACK_CHANNEL: ${{ inputs.slack_channel }}


### PR DESCRIPTION
This PR:

- pins `actions/checkout`, `actions/github-script` (x2), and `rtCamp/action-slack-notify` in `secrets-detection.yml` to full-length commit SHAs with version comments (v4.3.1, v7.1.0, v2.4.0)

## Context

ComposioHQ/composio enforces an actions policy requiring full-SHA pins, and the policy also applies to actions resolved inside called reusable workflows — so every Secrets Detection run in that repo currently ends in `startup_failure`:

> Error: The actions actions/checkout@v4, actions/github-script@v7, and rtcamp/action-slack-notify@v2 are not allowed in ComposioHQ/composio because all actions must be pinned to a full-length commit SHA

Callers can reference this commit SHA immediately (ComposioHQ/composio#3748 does); after merge, bump callers to the master SHA.