### PR TITLE
fix: use allowlisted Slack notification action

### DIFF
--- a/.github/workflows/secrets-detection.yml
+++ b/.github/workflows/secrets-detection.yml
@@ -114,23 +114,45 @@ jobs:
               });
             }
 
+      - name: Build Slack notification payload
+        id: slack-payload
+        if: failure() && steps.secret-scan.outputs.secrets_found == 'true'
+        env:
+          SLACK_CHANNEL: ${{ inputs.slack_channel }}
+          ALERT_COUNT: ${{ steps.secret-scan.outputs.alert_count }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          payload=$(jq -nc \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg branch "$BRANCH" \
+            --arg author "$GITHUB_ACTOR" \
+            --arg alerts "$ALERT_COUNT" \
+            --arg review "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/security/secret-scanning" \
+            --arg run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            '{
+              channel: $channel,
+              username: "Security Bot",
+              text: (
+                ":rotating_light: *Secrets Detected in PR*\n\n" +
+                "Potential secrets detected by GitHub Advanced Security.\n" +
+                "*Repository:* " + $repository + "\n" +
+                "*Branch:* " + $branch + "\n" +
+                "*Author:* " + $author + "\n" +
+                "*Alerts:* " + $alerts + "\n" +
+                "<" + $review + "|Review alerts> · <" + $run + "|Workflow run>\n\n" +
+                "Please review and remove any hardcoded secrets immediately."
+              )
+            }')
+
+          echo "payload<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$payload" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Slack Notification on Secrets Detection
         if: failure() && steps.secret-scan.outputs.secrets_found == 'true'
-        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_TECH_WEBHOOK }}
-          SLACK_CHANNEL: ${{ inputs.slack_channel }}
-          SLACK_COLOR: danger
-          SLACK_TITLE: ":rotating_light: Secrets Detected in PR"
-          SLACK_MESSAGE: |
-            Potential secrets detected in pull request by GitHub Advanced Security!
-            Repository: ${{ github.repository }}
-            Branch: ${{ github.head_ref || github.ref_name }}
-            Author: ${{ github.actor }}
-            Alerts: ${{ steps.secret-scan.outputs.alert_count }}
-            Review: https://github.com/${{ github.repository }}/security/secret-scanning
-            Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Please review and remove any hardcoded secrets immediately.
-          SLACK_FOOTER: "Security Alert — GitHub Advanced Security"
-          SLACK_USERNAME: "Security Bot"
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_TECH_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: ${{ steps.slack-payload.outputs.payload }}


### PR DESCRIPTION
## Summary

Secret-detection workflows can start under the organization Actions policy again. The previous Slack notifier pulled a disallowed action transitively, causing runners to reject the job before secret scanning began. Notifications now use the already-approved `slackapi` action while preserving the security channel and alert context.

Related: ComposioHQ/composio#3838

## Validation

- Parsed the reusable workflow with `yq`.
- Executed the payload builder with representative workflow environment values and validated the resulting JSON.
